### PR TITLE
supporting deleting question blocks

### DIFF
--- a/form-builder.css
+++ b/form-builder.css
@@ -65,3 +65,8 @@ ol.questions.compact {
     display: inline-block;
     width: 100%;
 }
+
+.lofi li:focus {
+	outline: 3px dashed rgba( 0, 0, 255, .5 );
+	outline-color: rgba( 0, 0, 255, .5 ) !important;
+}

--- a/form-builder.js
+++ b/form-builder.js
@@ -17,6 +17,10 @@ var formBuilder = (function ( $, style_html ) {
 		});
 	}
 
+	// setup initial keyboard focus
+	$( '.questions > li' ).prop( 'tabindex', 0 );
+
+
 	var currentHtml = '';
 	var KEY = {
 		ASTERISK: 106, // * (numpad)
@@ -194,6 +198,7 @@ var formBuilder = (function ( $, style_html ) {
 				$( '#editButtons' ).slideUp();
 				$( '.constructiform', '#content' ).removeClass( 'constructiform' );
 				$( '[draggable]' ).removeAttr( 'draggable' );
+				$( '.questions > li' ).removeProp( 'tabindex' ).removeAttr( 'tabindex' );
 
 				break;
 
@@ -208,6 +213,7 @@ var formBuilder = (function ( $, style_html ) {
 				$( '#toolbox' ).slideDown();
 				$( '#editButtons' ).slideDown();
 				resetDragging( true );
+				$( '.questions > li' ).prop( 'tabindex', 0 );
 				break;
 
 			case 'export html':
@@ -724,6 +730,7 @@ var formBuilder = (function ( $, style_html ) {
 	$( document ).on( 'submit', 'form', function () {
 		return false;
 	});
+
 
 	return {
 		config: config,


### PR DESCRIPTION
- add `tabindex` to `.questions > li` to allow keyboard focus (supports existing keyboard events like Delete)
- display blue border on li:focus
- remove tabindex when previewing or exporting
